### PR TITLE
Adding '.' to show extension

### DIFF
--- a/docs/cado-response/importing-data/filetypes.md
+++ b/docs/cado-response/importing-data/filetypes.md
@@ -31,7 +31,7 @@ In addition to native capture support for machines and data running/stored in th
 
 #### Storage Media
 - .E01, and split E01
-- .VHD and VHDX
+- .VHD and .VHDX
 - .DD (Optionally .GZ Compressed)
 - .GZ / .Tar / .Zip
 - .VMDK (Partial Support*)

--- a/docs/cado-response/importing-data/filetypes.md
+++ b/docs/cado-response/importing-data/filetypes.md
@@ -30,11 +30,11 @@ Cado Response supports the processing of a wide range of evidence types.  These 
 In addition to native capture support for machines and data running/stored in the cloud, Cado Response also supports processing of the following local evidence formats.  
 
 #### Storage Media
-- E01, and split E01
-- VHD and VHDX
-- DD (Optionally .GZ Compressed)
-- GZ / Tar / Zip
-- VMDK (Partial Support*)
+- .E01, and split E01
+- .VHD and VHDX
+- .DD (Optionally .GZ Compressed)
+- .GZ / .Tar / .Zip
+- .VMDK (Partial Support*)
 - Other forensic triage artifacts collected by EDR Tools or [Cado Host](https://docs.cadosecurity.com/cado-host/intro)
 
 To import a compressed dd image, compress with Gzip and add .gz to the extension. (example: `disk.dd.gz`)


### PR DESCRIPTION
We have had one customer expecting the platform to automatically detect the storage type (E01) when importing an evidence file with no file extension.