### PR TITLE
Update azure instructions to specify RSA when generating SSH key

### DIFF
--- a/docs/cado/deploy/azure/azure-deploy.md
+++ b/docs/cado/deploy/azure/azure-deploy.md
@@ -89,7 +89,7 @@ Once you receive them, continue on to the steps below.
     :::
 
     ```console
-    ssh-keygen -b 4096 -f ../keys/azure_demo_key -q -N ""
+    ssh-keygen -t rsa -b 4096 -f ../keys/azure_demo_key -q -N ""
     ```
 
 9. Customize the file `azure/cado/main.tf` by filling in the default values for the following variables:


### PR DESCRIPTION
Since late 2023 default OpenSSH behaviour has been to use ED25519 (which azure doesn't support). We should specify RSA instead. 