### PR TITLE
Update GCP Permissions Docs

### DIFF
--- a/docs/cado/deploy/gcp/gcp-settings.md
+++ b/docs/cado/deploy/gcp/gcp-settings.md
@@ -46,6 +46,8 @@ If you're deploying into GCP, the Terraform script provided by Cado should have 
     "compute.images.delete",
     "compute.images.get",
     "compute.instances.getSerialPortOutput",
+    "compute.subnetworks.list",
+    "compute.subnetworks.get",
 
     // Compute Management
     "compute.disks.create",


### PR DESCRIPTION
### Description
- Updated Docs on GCP permissions since these are required for Cloud Build to use the subnet the acquired instance is run in for Daisy workers.
- Also updated the GCP set up scripts: https://github.com/cado-security/gcp-setup/pull/2